### PR TITLE
change indexing

### DIFF
--- a/google_colab/table_xml.py
+++ b/google_colab/table_xml.py
@@ -13,8 +13,8 @@ def output_to_xml(table_coords, list_table_boxes):
         start_x = table_coords[i][0]
         start_y = table_coords[i][1]
 
-        for j in range(len(list_table_boxes[0])):
-            for k in range(len(list_table_boxes[0][0])):
+        for j in range(len(list_table_boxes[i])):
+            for k in range(len(list_table_boxes[i][j])):
 
                 cell = etree.SubElement(table, "cell")
                 cell.attrib["row"] = str(j)


### PR DESCRIPTION
When extracting multiple tables with a different count of cells, the previous indexing fails and therefore must be adjusted.